### PR TITLE
Add category to library.properties

### DIFF
--- a/temboo-arduino-library-1.2/Temboo/library.properties
+++ b/temboo-arduino-library-1.2/Temboo/library.properties
@@ -3,6 +3,7 @@ author=Temboo
 email=support@temboo.com
 sentence=This library enables calls to Temboo, a platform that connects Arduino boards to 100+ APIs, databases, code utilities and more. 
 paragraph=Use this library to connect your Arduino board to Temboo, making it simple to interact with a vast array of web-based resources and services.
+category=Communication
 url=http://www.temboo.com/arduino
 architectures=*
 version=1.1


### PR DESCRIPTION
Lack of a category field in library.properties causes the warning:
```
WARNING: Category '' in library Temboo is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format